### PR TITLE
Prevent `NullPointerException` in `cleanupSpec`

### DIFF
--- a/src/testFixtures/groovy/grails/plugin/geb/ContainerGebSpec.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/ContainerGebSpec.groovy
@@ -79,7 +79,7 @@ class ContainerGebSpec extends GebSpec {
     }
 
     def cleanupSpec() {
-        webDriverContainer.stop()
+        webDriverContainer?.stop()
     }
 
     /**


### PR DESCRIPTION
If a `ContainerGebSpec` test is not annotated with `@Integration`, the `webDriverContainer` is null in `cleanupSpec`. This fix ensures that `cleanupSpec` checks for a null `webDriverContainer`, preventing a NullPointerException during cleanup for non-`@Integration` tests.