### PR TITLE
Use Gradle java version release flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,8 @@ apply plugin: 'org.grails.grails-plugin'
 apply plugin: 'org.grails.internal.grails-plugin-publish'
 apply plugin: 'maven-publish'
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-        vendor = JvmVendorSpec.BELLSOFT
-    }
+tasks.withType(JavaCompile).configureEach {
+    options.release = 17
 }
 
 repositories {


### PR DESCRIPTION
Using toolchain will not allow Github actions to override the version.