### PR TITLE
Add reporting support to ContainerGebSpec

### DIFF
--- a/src/testFixtures/groovy/grails/plugin/geb/ContainerGebSpec.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/ContainerGebSpec.groovy
@@ -62,7 +62,7 @@ abstract class ContainerGebSpec extends Specification implements ManagedGebTest,
     @Override
     @Delegate(includes = ['getBrowser', 'report'])
     GebTestManager getTestManager() {
-        return getReportingEnabled() ?
+        return isReportingEnabled() ?
                 GebTestManagerProvider.getReportingInstance() :
                 GebTestManagerProvider.getInstance()
     }

--- a/src/testFixtures/groovy/grails/plugin/geb/ContainerGebSpec.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/ContainerGebSpec.groovy
@@ -15,9 +15,9 @@
  */
 package grails.plugin.geb
 
-import geb.spock.GebSpec
-import groovy.transform.CompileDynamic
-import groovy.transform.CompileStatic
+import geb.test.GebTestManager
+import geb.test.ManagedGebTest
+import geb.transform.DynamicallyDispatchesToBrowser
 import groovy.transform.PackageScope
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.chrome.ChromeOptions
@@ -26,6 +26,7 @@ import org.testcontainers.Testcontainers
 import org.testcontainers.containers.BrowserWebDriverContainer
 import org.testcontainers.containers.PortForwardingContainer
 import spock.lang.Shared
+import spock.lang.Specification
 
 import java.time.Duration
 
@@ -47,14 +48,24 @@ import java.time.Duration
  * @author Mattias Reichel
  * @since 5.0.0
  */
-@CompileStatic
-abstract class ContainerGebSpec extends GebSpec implements ContainerAwareDownloadSupport {
+@DynamicallyDispatchesToBrowser
+abstract class ContainerGebSpec extends Specification implements ManagedGebTest, ContainerAwareDownloadSupport {
 
     private static final String DEFAULT_HOSTNAME_FROM_CONTAINER = 'host.testcontainers.internal'
     private static final String DEFAULT_HOSTNAME_FROM_HOST = 'localhost'
     private static final String DEFAULT_PROTOCOL = 'http'
 
     private String hostNameFromContainer = DEFAULT_HOSTNAME_FROM_CONTAINER
+
+    boolean reportingEnabled = false
+
+    @Override
+    @Delegate(includes = ['getBrowser', 'report'])
+    GebTestManager getTestManager() {
+        return getReportingEnabled() ?
+                GebTestManagerProvider.getReportingInstance() :
+                GebTestManagerProvider.getInstance()
+    }
 
     @Shared
     BrowserWebDriverContainer webDriverContainer
@@ -146,7 +157,6 @@ abstract class ContainerGebSpec extends GebSpec implements ContainerAwareDownloa
         }
     }
 
-    @CompileDynamic
     private static String getHostIp() {
         PortForwardingContainer.INSTANCE.network.get().ipAddress
     }

--- a/src/testFixtures/groovy/grails/plugin/geb/GebTestManagerProvider.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/GebTestManagerProvider.groovy
@@ -1,0 +1,36 @@
+package grails.plugin.geb
+
+import geb.spock.SpockGebTestManagerBuilder
+import geb.test.GebTestManager
+
+class GebTestManagerProvider {
+
+    private static volatile GebTestManager INSTANCE
+    private static volatile GebTestManager REPORTING_INSTANCE
+
+    private GebTestManagerProvider() {}
+
+    static GebTestManager getInstance() {
+        if (INSTANCE == null) {
+            synchronized (GebTestManagerProvider) {
+                if (INSTANCE == null) {
+                    INSTANCE = new SpockGebTestManagerBuilder().build()
+                }
+            }
+        }
+        return INSTANCE
+    }
+
+    static GebTestManager getReportingInstance() {
+        if (REPORTING_INSTANCE == null) {
+            synchronized (GebTestManagerProvider) {
+                if (REPORTING_INSTANCE == null) {
+                    REPORTING_INSTANCE = new SpockGebTestManagerBuilder()
+                            .withReportingEnabled(true)
+                            .build()
+                }
+            }
+        }
+        return REPORTING_INSTANCE
+    }
+}

--- a/src/testFixtures/groovy/grails/plugin/geb/GebTestManagerProvider.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/GebTestManagerProvider.groovy
@@ -1,36 +1,71 @@
+/*
+ * Copyright 2024 original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package grails.plugin.geb
 
 import geb.spock.SpockGebTestManagerBuilder
 import geb.test.GebTestManager
+import groovy.transform.CompileStatic
 
+/**
+ * A provider class for managing instances of {@link GebTestManager}.
+ * This class uses the Initialization-on-Demand Holder Idiom to ensure thread-safe,
+ * lazy initialization of {@link GebTestManager} instances for use in Geb tests.
+ *
+ * <p>The class provides two static instances:</p>
+ * <ul>
+ *   <li>{@code instance}: A standard {@link GebTestManager} instance.</li>
+ *   <li>{@code reportingInstance}: A {@link GebTestManager} instance with reporting enabled.</li>
+ * </ul>
+ *
+ * <p>This class cannot be instantiated, as it is designed to be used as a
+ * utility provider.</p>
+ *
+ * @see GebTestManager
+ * @see SpockGebTestManagerBuilder
+ *
+ * @author Mattias Reichel
+ * @author Søren Berg Glasius
+ * @since 5.0
+ */
+@CompileStatic
 class GebTestManagerProvider {
 
-    private static volatile GebTestManager INSTANCE
-    private static volatile GebTestManager REPORTING_INSTANCE
+    /**
+     * A lazily and thread-safe-initialized instance of {@link GebTestManager}.
+     * Built using {@link SpockGebTestManagerBuilder}.
+     */
+    @Lazy
+    static volatile GebTestManager instance = {
+        new SpockGebTestManagerBuilder().build()
+    }()
 
+    /**
+     * A lazily and thread-safe-initialized instance of {@link GebTestManager}
+     * with reporting enabled. Built using {@link SpockGebTestManagerBuilder}.
+     */
+    @Lazy
+    static volatile GebTestManager reportingInstance = {
+        new SpockGebTestManagerBuilder()
+                .withReportingEnabled(true)
+                .build()
+    }()
+
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
     private GebTestManagerProvider() {}
 
-    static GebTestManager getInstance() {
-        if (INSTANCE == null) {
-            synchronized (GebTestManagerProvider) {
-                if (INSTANCE == null) {
-                    INSTANCE = new SpockGebTestManagerBuilder().build()
-                }
-            }
-        }
-        return INSTANCE
-    }
-
-    static GebTestManager getReportingInstance() {
-        if (REPORTING_INSTANCE == null) {
-            synchronized (GebTestManagerProvider) {
-                if (REPORTING_INSTANCE == null) {
-                    REPORTING_INSTANCE = new SpockGebTestManagerBuilder()
-                            .withReportingEnabled(true)
-                            .build()
-                }
-            }
-        }
-        return REPORTING_INSTANCE
-    }
 }


### PR DESCRIPTION
Introduces a `boolean reportingEnabled = false` property in `ContainerGebSpec` that subclasses can override to enable reporting functionality.

To enable reporting, you must also specify the `reportsDir` property. This can typically be configured in `resources/GebConfig.groovy` or via the `geb.reportsDir` system property.