### PR TITLE
Remove compilation warning about missing `slf4j` impl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     compileOnly 'org.grails:grails-core' // Provided as this is a Grails plugin
 
     testFixturesCompileOnly 'jakarta.servlet:jakarta.servlet-api'
+    testFixturesCompileOnly 'org.slf4j:slf4j-simple' // Remove compilation warning about missing slf4j impl
     testFixturesApi 'org.gebish:geb-spock'
     testFixturesApi 'org.grails:grails-testing-support'
     testFixturesApi 'org.grails:grails-datastore-gorm'


### PR DESCRIPTION
```console
> Task :compileTestFixturesGroovy
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
```