### PR TITLE
Fix test name to include specification & feature name

### DIFF
--- a/src/testFixtures/groovy/grails/plugin/geb/ContainerGebTestDescription.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/ContainerGebTestDescription.groovy
@@ -32,7 +32,13 @@ class ContainerGebTestDescription implements TestDescription {
     String filesystemFriendlyName
 
     ContainerGebTestDescription(IterationInfo testInfo) {
-        testId = testInfo.displayName
+        testId = [
+                testInfo.feature.spec.displayName,
+                testInfo.feature.displayName,
+                testInfo.displayName != testInfo.feature.displayName ? testInfo.displayName : null,
+                testInfo.displayName != testInfo.feature.displayName ? testInfo.iterationIndex : null
+        ].findAll(/* Remove nulls */).join(' ')
+
         String safeName = testId.replaceAll('\\W+', '_')
         filesystemFriendlyName = safeName
     }


### PR DESCRIPTION
I was only putting the method name in the saved file name, now the file will have the full path. 

Here's an example after this change: 
<img width="823" alt="image" src="https://github.com/user-attachments/assets/73e3f530-077d-4d79-b796-8b103cbd010e">

Before it would have been `PASSED-should_be_able_to_use_download_methods-20241209-140435.mp4`
