### PR TITLE
Fix includeBuild syntax so it works with grailsPublish

### DIFF
--- a/spock-container-test-app/build.gradle
+++ b/spock-container-test-app/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     testImplementation 'org.grails:grails-web-testing-support'
     testImplementation 'org.spockframework:spock-core'
 
-    integrationTestImplementation testFixtures(project(':geb'))
+    integrationTestImplementation testFixtures('org.grails.plugins:geb')
 }
 
 compileJava.options.release = 17

--- a/spock-container-test-app/settings.gradle
+++ b/spock-container-test-app/settings.gradle
@@ -27,4 +27,4 @@ buildCache {
 
 rootProject.name = 'spock-container-test-app'
 
-includeBuild("..")
+includeBuild('..')

--- a/spock-container-test-app/settings.gradle
+++ b/spock-container-test-app/settings.gradle
@@ -27,5 +27,4 @@ buildCache {
 
 rootProject.name = 'spock-container-test-app'
 
-include 'geb'
-project(':geb').projectDir = file('..')
+includeBuild("..")


### PR DESCRIPTION
@matrei & I noticed that the tests in the test project fail to run when the project version is considered a release version.  The error it gives is: 

     A problem occurred evaluating project ':geb'.
     > Failed to apply plugin class 'io.github.gradlenexus.publishplugin.NexusPublishPlugin'.
        > Cannot run Project.afterEvaluate(Action) when the project is already evaluated.

The existing include syntax in the build causes this.  After adding end to end testing for the grails-gradle-plugin (https://github.com/jdaugherty/grails-gradle-plugin/actions/runs/12404566767), I was able to isolate this and discovered there's also a [includeBuild](https://docs.gradle.org/current/userguide/composite_builds.html#settings_defined_composite) syntax. 

Switching to the includeBuild syntax fixes the subproject so it works regardless of the geb project's version.  