### PR TITLE
Delegate to page object for missing methods and properties

### DIFF
--- a/spock-container-test-app/src/integration-test/groovy/org/demo/spock/PageDelegateSpec.groovy
+++ b/spock-container-test-app/src/integration-test/groovy/org/demo/spock/PageDelegateSpec.groovy
@@ -1,0 +1,21 @@
+package org.demo.spock
+
+import grails.plugin.geb.ContainerGebSpec
+import grails.testing.mixin.integration.Integration
+import org.demo.spock.pages.UploadPage
+
+@Integration
+class PageDelegateSpec extends ContainerGebSpec {
+
+    void 'should delegate to page object'() {
+        given:
+        to UploadPage
+
+        when:
+        nop()
+
+        then:
+        title == 'Upload Test'
+    }
+
+}

--- a/spock-container-test-app/src/integration-test/groovy/org/demo/spock/pages/UploadPage.groovy
+++ b/spock-container-test-app/src/integration-test/groovy/org/demo/spock/pages/UploadPage.groovy
@@ -12,4 +12,8 @@ class UploadPage extends Page {
         fileInput { $('input', name: 'myFile').module(FileInput) }
         submitBtn { $('input', type: 'submit') }
     }
+
+    void nop() {
+        // no-op
+    }
 }

--- a/src/testFixtures/groovy/grails/plugin/geb/support/delegate/BrowserDelegate.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/support/delegate/BrowserDelegate.groovy
@@ -240,15 +240,17 @@ trait BrowserDelegate {
     }
 
     @CompileDynamic
-    void methodMissing(String name, Object[] args) {
-        browser[name](*args)
+    def methodMissing(String name, args) {
+        browser.page."$name"(*args)
     }
 
-    void propertyMissing(String name, Object value) {
-        browser[name] = value
+    @CompileDynamic
+    def propertyMissing(String name) {
+        browser.page."$name"
     }
 
-    Object propertyMissing(String name) {
-        browser[name]
+    @CompileDynamic
+    def propertyMissing(String name, value) {
+        browser.page."$name" = value
     }
 }


### PR DESCRIPTION
Fixes an issue where delegation to the page object was broken after removing `@DynamicallyDispatchesToBrowser`.

This commit restores proper delegation by implementing `methodMissing` and `propertyMissing` to handle dynamic method and property calls.