### PR TITLE
feat: include ScreenshotReporter by default in container too

### DIFF
--- a/spock-container-test-app/src/integration-test/groovy/org/demo/spock/RootPageSpec.groovy
+++ b/spock-container-test-app/src/integration-test/groovy/org/demo/spock/RootPageSpec.groovy
@@ -3,7 +3,6 @@ package org.demo.spock
 import geb.report.CompositeReporter
 import geb.report.PageSourceReporter
 import geb.report.Reporter
-import geb.report.ScreenshotReporter
 import grails.plugin.geb.ContainerGebConfiguration
 import grails.plugin.geb.ContainerGebSpec
 import grails.testing.mixin.integration.Integration

--- a/spock-container-test-app/src/integration-test/groovy/org/demo/spock/RootPageSpec.groovy
+++ b/spock-container-test-app/src/integration-test/groovy/org/demo/spock/RootPageSpec.groovy
@@ -19,7 +19,7 @@ class RootPageSpec extends ContainerGebSpec {
     @Override
     Reporter createReporter() {
         // Override the default reporter to demonstrate how this can be customized
-        new CompositeReporter(new ScreenshotReporter(), new PageSourceReporter())
+        new CompositeReporter(new PageSourceReporter())
     }
 
     void 'should display the correct title on the home page'() {

--- a/src/testFixtures/groovy/grails/plugin/geb/support/ReportingSupport.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/support/ReportingSupport.groovy
@@ -18,6 +18,7 @@ package grails.plugin.geb.support
 import geb.report.CompositeReporter
 import geb.report.PageSourceReporter
 import geb.report.Reporter
+import geb.report.ScreenshotReporter
 import grails.plugin.geb.ContainerGebSpec
 import groovy.transform.CompileStatic
 import groovy.transform.SelfType
@@ -41,6 +42,6 @@ trait ReportingSupport {
      * The reporter that Geb should use when reporting is enabled.
      */
     Reporter createReporter() {
-        new CompositeReporter(new PageSourceReporter())
+        return new CompositeReporter(new PageSourceReporter(), new ScreenshotReporter())
     }
 }


### PR DESCRIPTION
as done when would-be-using GebConfig.groovy

https://github.com/apache/groovy-geb/blob/917df94c29b71f9eeec940ee1462ba2a4285489d/module/geb-core/src/main/groovy/geb/Configuration.groovy#L679