### PR TITLE
feat: allow to configure implicit wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ By default, no test recording will be performed.  Here are the system properties
 
 #### Remove Implicit Wait
 
-* `grails.geb.timeouts.implicitlyWait`
+* `grails.geb.webdriver.timeouts.implicitlyWait`
   * purpose: global setting that applies to every element location call for the entire session 
   * defaults to `0` seconds, which means that if an element is not found, it will immediately return an error.
   * Warning: Do not mix implicit and explicit waits. Doing so can cause unpredictable wait times.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ By default, no test recording will be performed.  Here are the system properties
 
 #### Remove Implicit Wait
 
-* `grails.geb.implicit_wait`
+* `grails.geb.implicitWait`
   * purpose: test-containers edge case  
   * defaults to `30` (seconds) 
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ By default, no test recording will be performed.  Here are the system properties
     * possible values are `FLV` or `MP4`
     * defaults to `MP4`
 
+#### Remove Implicit Wait
+
+* `grails.geb.implicit_wait`
+  * purpose: test-containers edge case  
+  * defaults to `30` (seconds) 
+
+
 #### Observability and Tracing
 Selenium integrates with [OpenTelemetry](https://opentelemetry.io) to support observability and tracing out of the box. By default, Selenium [enables tracing](https://www.selenium.dev/blog/2021/selenium-4-observability).
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ By default, no test recording will be performed.  Here are the system properties
 
 #### Remove Implicit Wait
 
-* `grails.geb.implicitWait`
-  * purpose: test-containers edge case  
-  * defaults to `30` (seconds) 
+* `grails.geb.timeouts.implicitlyWait`
+  * purpose: global setting that applies to every element location call for the entire session 
+  * defaults to `0` seconds, which means that if an element is not found, it will immediately return an error.
+  * Warning: Do not mix implicit and explicit waits. Doing so can cause unpredictable wait times.
+    Consult the Geb and/or https://www.selenium.dev/documentation/webdriver/waits/[Selenium] documentation for details.
 
 
 #### Observability and Tracing

--- a/README.md
+++ b/README.md
@@ -78,17 +78,18 @@ By default, no test recording will be performed.  Here are the system properties
 
 #### Remove Implicit Wait
 
-* `grails.geb.webdriver.timeouts.implicitlyWait`
+* `grails.geb.timeouts.implicitlyWait`
   * purpose: amount of time the driver should wait when searching for an element if it is not immediately present.
   * defaults to `0` seconds, which means that if an element is not found, it will immediately return an error.
   * Warning: Do not mix implicit and explicit waits. Doing so can cause unpredictable wait times.
-    Consult the Geb and/or https://www.selenium.dev/documentation/webdriver/waits/[Selenium] documentation for details.
-* `grails.geb.webdriver.timeouts.pageLoadTimeout`
+    Consult the [Geb](https://www.gebish.org/manual/current/#implicit-assertions-waiting) 
+    and/or [Selenium](https://www.selenium.dev/documentation/webdriver/waits/) documentation for details.
+* `grails.geb.timeouts.pageLoad`
   * purpose: amount of time to wait for a page load to complete before throwing an error.
-  * defaults to `0` seconds
-* `grails.geb.webdriver.timeouts.script`
+  * defaults to `300` seconds
+* `grails.geb.timeouts.script`
   * purpose: amount of time to wait for an asynchronous script to finish execution before throwing an error.
-  * defaults to `0` seconds
+  * defaults to `30` seconds
 
 #### Observability and Tracing
 Selenium integrates with [OpenTelemetry](https://opentelemetry.io) to support observability and tracing out of the box. By default, Selenium [enables tracing](https://www.selenium.dev/blog/2021/selenium-4-observability).

--- a/README.md
+++ b/README.md
@@ -79,11 +79,16 @@ By default, no test recording will be performed.  Here are the system properties
 #### Remove Implicit Wait
 
 * `grails.geb.webdriver.timeouts.implicitlyWait`
-  * purpose: global setting that applies to every element location call for the entire session 
+  * purpose: amount of time the driver should wait when searching for an element if it is not immediately present.
   * defaults to `0` seconds, which means that if an element is not found, it will immediately return an error.
   * Warning: Do not mix implicit and explicit waits. Doing so can cause unpredictable wait times.
     Consult the Geb and/or https://www.selenium.dev/documentation/webdriver/waits/[Selenium] documentation for details.
-
+* `grails.geb.webdriver.timeouts.pageLoadTimeout`
+  * purpose: amount of time to wait for a page load to complete before throwing an error.
+  * defaults to `0` seconds
+* `grails.geb.webdriver.timeouts.script`
+  * purpose: amount of time to wait for an asynchronous script to finish execution before throwing an error.
+  * defaults to `0` seconds
 
 #### Observability and Tracing
 Selenium integrates with [OpenTelemetry](https://opentelemetry.io) to support observability and tracing out of the box. By default, Selenium [enables tracing](https://www.selenium.dev/blog/2021/selenium-4-observability).

--- a/src/testFixtures/groovy/grails/plugin/geb/GrailsGebSettings.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/GrailsGebSettings.groovy
@@ -58,7 +58,7 @@ class GrailsGebSettings {
                 System.getProperty('grails.geb.recording.format', DEFAULT_RECORDING_FORMAT.name())
         )
         try {
-            implicitlyWait = Integer.parseInt(System.getProperty('grails.geb.timeouts.implicitlyWait'))
+            implicitlyWait = Integer.parseInt(System.getProperty('grails.geb.webdriver.timeouts.implicitlyWait'))
         } catch (NumberFormatException ignored) {
             implicitlyWait = DEFAULT_IMPLICIT_WAIT
         }

--- a/src/testFixtures/groovy/grails/plugin/geb/GrailsGebSettings.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/GrailsGebSettings.groovy
@@ -37,7 +37,7 @@ class GrailsGebSettings {
 
     private static VncRecordingMode DEFAULT_RECORDING_MODE = VncRecordingMode.SKIP
     private static VncRecordingFormat DEFAULT_RECORDING_FORMAT = VncRecordingFormat.MP4
-    private static int DEFAULT_IMPLICIT_WAIT = 30
+    private static int DEFAULT_IMPLICIT_WAIT = 0
 
     String tracingEnabled
     String recordingDirectoryName
@@ -45,7 +45,7 @@ class GrailsGebSettings {
     VncRecordingMode recordingMode
     VncRecordingFormat recordingFormat
     LocalDateTime startTime
-    int implicitWait
+    int implicitlyWait
 
     GrailsGebSettings(LocalDateTime startTime) {
         tracingEnabled = System.getProperty('grails.geb.tracing.enabled', 'false')
@@ -58,9 +58,9 @@ class GrailsGebSettings {
                 System.getProperty('grails.geb.recording.format', DEFAULT_RECORDING_FORMAT.name())
         )
         try {
-            implicitWait = Integer.parseInt(System.getProperty('grails.geb.implicitWait'))
+            implicitlyWait = Integer.parseInt(System.getProperty('grails.geb.timeouts.implicitlyWait'))
         } catch (NumberFormatException ignored) {
-            implicitWait = DEFAULT_IMPLICIT_WAIT
+            implicitlyWait = DEFAULT_IMPLICIT_WAIT
         }
         this.startTime = startTime
     }

--- a/src/testFixtures/groovy/grails/plugin/geb/GrailsGebSettings.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/GrailsGebSettings.groovy
@@ -57,7 +57,7 @@ class GrailsGebSettings {
                 System.getProperty('grails.geb.recording.format', DEFAULT_RECORDING_FORMAT.name())
         )
         try {
-            implicitWait = Integer.parseInt(System.getProperty('grails.geb.implicit_wait', '30'))
+            implicitWait = Integer.parseInt(System.getProperty('grails.geb.implicitWait', '30'))
         } catch (NumberFormatException ignored) {
             implicitWait = 30
         }

--- a/src/testFixtures/groovy/grails/plugin/geb/GrailsGebSettings.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/GrailsGebSettings.groovy
@@ -38,6 +38,8 @@ class GrailsGebSettings {
     private static VncRecordingMode DEFAULT_RECORDING_MODE = VncRecordingMode.SKIP
     private static VncRecordingFormat DEFAULT_RECORDING_FORMAT = VncRecordingFormat.MP4
     private static int DEFAULT_IMPLICIT_WAIT = 0
+    private static int DEFAULT_PAGE_LOAD_TIMEOUT = 0
+    private static int DEFAULT_SCRIPT_TIMEOUT = 0
 
     String tracingEnabled
     String recordingDirectoryName
@@ -46,6 +48,8 @@ class GrailsGebSettings {
     VncRecordingFormat recordingFormat
     LocalDateTime startTime
     int implicitlyWait
+    int pageLoadTimeout
+    int scriptTimeout
 
     GrailsGebSettings(LocalDateTime startTime) {
         tracingEnabled = System.getProperty('grails.geb.tracing.enabled', 'false')
@@ -61,6 +65,18 @@ class GrailsGebSettings {
             implicitlyWait = Integer.parseInt(System.getProperty('grails.geb.webdriver.timeouts.implicitlyWait'))
         } catch (NumberFormatException ignored) {
             implicitlyWait = DEFAULT_IMPLICIT_WAIT
+        }
+
+        try {
+            pageLoadTimeout = Integer.parseInt(System.getProperty('grails.geb.webdriver.timeouts.pageLoad'))
+        } catch (NumberFormatException ignored) {
+            pageLoadTimeout = DEFAULT_PAGE_LOAD_TIMEOUT
+        }
+
+        try {
+            scriptTimeout = Integer.parseInt(System.getProperty('grails.geb.webdriver.timeouts.script'))
+        } catch (NumberFormatException ignored) {
+            scriptTimeout = DEFAULT_SCRIPT_TIMEOUT
         }
         this.startTime = startTime
     }

--- a/src/testFixtures/groovy/grails/plugin/geb/GrailsGebSettings.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/GrailsGebSettings.groovy
@@ -37,6 +37,7 @@ class GrailsGebSettings {
 
     private static VncRecordingMode DEFAULT_RECORDING_MODE = VncRecordingMode.SKIP
     private static VncRecordingFormat DEFAULT_RECORDING_FORMAT = VncRecordingFormat.MP4
+    private static int DEFAULT_IMPLICIT_WAIT = 30
 
     String tracingEnabled
     String recordingDirectoryName
@@ -44,7 +45,7 @@ class GrailsGebSettings {
     VncRecordingMode recordingMode
     VncRecordingFormat recordingFormat
     LocalDateTime startTime
-    Integer implicitWait
+    int implicitWait
 
     GrailsGebSettings(LocalDateTime startTime) {
         tracingEnabled = System.getProperty('grails.geb.tracing.enabled', 'false')
@@ -57,9 +58,9 @@ class GrailsGebSettings {
                 System.getProperty('grails.geb.recording.format', DEFAULT_RECORDING_FORMAT.name())
         )
         try {
-            implicitWait = Integer.parseInt(System.getProperty('grails.geb.implicitWait', '30'))
+            implicitWait = Integer.parseInt(System.getProperty('grails.geb.implicitWait'))
         } catch (NumberFormatException ignored) {
-            implicitWait = 30
+            implicitWait = DEFAULT_IMPLICIT_WAIT
         }
         this.startTime = startTime
     }

--- a/src/testFixtures/groovy/grails/plugin/geb/GrailsGebSettings.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/GrailsGebSettings.groovy
@@ -44,6 +44,7 @@ class GrailsGebSettings {
     VncRecordingMode recordingMode
     VncRecordingFormat recordingFormat
     LocalDateTime startTime
+    Integer implicitWait
 
     GrailsGebSettings(LocalDateTime startTime) {
         tracingEnabled = System.getProperty('grails.geb.tracing.enabled', 'false')
@@ -55,6 +56,11 @@ class GrailsGebSettings {
         recordingFormat = VncRecordingFormat.valueOf(
                 System.getProperty('grails.geb.recording.format', DEFAULT_RECORDING_FORMAT.name())
         )
+        try {
+            implicitWait = Integer.parseInt(System.getProperty('grails.geb.implicit_wait', '30'))
+        } catch (NumberFormatException ignored) {
+            implicitWait = 30
+        }
         this.startTime = startTime
     }
 

--- a/src/testFixtures/groovy/grails/plugin/geb/GrailsGebSettings.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/GrailsGebSettings.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 original author or authors
+ * Copyright 2024-2025 original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,9 +37,9 @@ class GrailsGebSettings {
 
     private static VncRecordingMode DEFAULT_RECORDING_MODE = VncRecordingMode.SKIP
     private static VncRecordingFormat DEFAULT_RECORDING_FORMAT = VncRecordingFormat.MP4
-    private static int DEFAULT_IMPLICIT_WAIT = 0
-    private static int DEFAULT_PAGE_LOAD_TIMEOUT = 0
-    private static int DEFAULT_SCRIPT_TIMEOUT = 0
+    private static int DEFAULT_TIMEOUT_IMPLICITLY_WAIT = 0
+    private static int DEFAULT_TIMEOUT_PAGE_LOAD = 300
+    private static int DEFAULT_TIMEOUT_SCRIPT = 30
 
     String tracingEnabled
     String recordingDirectoryName
@@ -61,24 +61,14 @@ class GrailsGebSettings {
         recordingFormat = VncRecordingFormat.valueOf(
                 System.getProperty('grails.geb.recording.format', DEFAULT_RECORDING_FORMAT.name())
         )
-        try {
-            implicitlyWait = Integer.parseInt(System.getProperty('grails.geb.webdriver.timeouts.implicitlyWait'))
-        } catch (NumberFormatException ignored) {
-            implicitlyWait = DEFAULT_IMPLICIT_WAIT
-        }
-
-        try {
-            pageLoadTimeout = Integer.parseInt(System.getProperty('grails.geb.webdriver.timeouts.pageLoad'))
-        } catch (NumberFormatException ignored) {
-            pageLoadTimeout = DEFAULT_PAGE_LOAD_TIMEOUT
-        }
-
-        try {
-            scriptTimeout = Integer.parseInt(System.getProperty('grails.geb.webdriver.timeouts.script'))
-        } catch (NumberFormatException ignored) {
-            scriptTimeout = DEFAULT_SCRIPT_TIMEOUT
-        }
+        implicitlyWait = getIntProperty('grails.geb.timeouts.implicitlyWait', DEFAULT_TIMEOUT_IMPLICITLY_WAIT)
+        pageLoadTimeout = getIntProperty('grails.geb.timeouts.pageLoad', DEFAULT_TIMEOUT_PAGE_LOAD)
+        scriptTimeout = getIntProperty('grails.geb.timeouts.script', DEFAULT_TIMEOUT_SCRIPT)
         this.startTime = startTime
+    }
+
+    private static int getIntProperty(String propertyName, int defaultValue) {
+        Integer.getInteger(propertyName, defaultValue) ?: defaultValue
     }
 
     boolean isRecordingEnabled() {

--- a/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 original author or authors
+ * Copyright 2024-2025 original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import groovy.transform.EqualsAndHashCode
 import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
 import org.openqa.selenium.WebDriver
+import org.openqa.selenium.WebDriver.Timeouts
 import org.openqa.selenium.chrome.ChromeOptions
 import org.openqa.selenium.remote.RemoteWebDriver
 import org.spockframework.runtime.extension.IMethodInvocation
@@ -121,14 +122,10 @@ class WebDriverContainerHolder {
         currentBrowser = new Browser(new Configuration(configObject, new Properties(), null, null))
 
         WebDriver driver = new RemoteWebDriver(currentContainer.seleniumAddress, new ChromeOptions())
-        if (grailsGebSettings.implicitlyWait > 0) {
-            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(grailsGebSettings.implicitlyWait))
-        }
-        if (grailsGebSettings.pageLoadTimeout > 0) {
-            driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(grailsGebSettings.pageLoadTimeout))
-        }
-        if (grailsGebSettings.scriptTimeout > 0) {
-            driver.manage().timeouts().scriptTimeout(Duration.ofSeconds(grailsGebSettings.scriptTimeout))
+        driver.manage().timeouts().with {Timeouts it ->
+            it.implicitlyWait(Duration.ofSeconds(grailsGebSettings.implicitlyWait))
+            it.pageLoadTimeout(Duration.ofSeconds(grailsGebSettings.pageLoadTimeout))
+            it.scriptTimeout(Duration.ofSeconds(grailsGebSettings.scriptTimeout))
         }
 
         currentBrowser.driver = driver

--- a/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
@@ -121,8 +121,8 @@ class WebDriverContainerHolder {
         currentBrowser = new Browser(new Configuration(configObject, new Properties(), null, null))
 
         WebDriver driver = new RemoteWebDriver(currentContainer.seleniumAddress, new ChromeOptions())
-        if (grailsGebSettings.implicitWait > 0) {
-            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(grailsGebSettings.implicitWait))
+        if (grailsGebSettings.implicitlyWait > 0) {
+            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(grailsGebSettings.implicitlyWait))
         }
 
         currentBrowser.driver = driver

--- a/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
@@ -122,7 +122,7 @@ class WebDriverContainerHolder {
 
         WebDriver driver = new RemoteWebDriver(currentContainer.seleniumAddress, new ChromeOptions())
         if (grailsGebSettings.implicitWait > 0) {
-            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30))
+            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(grailsGebSettings.implicitWait))
         }
 
         currentBrowser.driver = driver

--- a/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
@@ -122,10 +122,10 @@ class WebDriverContainerHolder {
         currentBrowser = new Browser(new Configuration(configObject, new Properties(), null, null))
 
         WebDriver driver = new RemoteWebDriver(currentContainer.seleniumAddress, new ChromeOptions())
-        driver.manage().timeouts().with {Timeouts it ->
-            it.implicitlyWait(Duration.ofSeconds(grailsGebSettings.implicitlyWait))
-            it.pageLoadTimeout(Duration.ofSeconds(grailsGebSettings.pageLoadTimeout))
-            it.scriptTimeout(Duration.ofSeconds(grailsGebSettings.scriptTimeout))
+        driver.manage().timeouts().with {
+            implicitlyWait(Duration.ofSeconds(grailsGebSettings.implicitlyWait))
+            pageLoadTimeout(Duration.ofSeconds(grailsGebSettings.pageLoadTimeout))
+            scriptTimeout(Duration.ofSeconds(grailsGebSettings.scriptTimeout))
         }
 
         currentBrowser.driver = driver

--- a/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
@@ -121,7 +121,9 @@ class WebDriverContainerHolder {
         currentBrowser = new Browser(new Configuration(configObject, new Properties(), null, null))
 
         WebDriver driver = new RemoteWebDriver(currentContainer.seleniumAddress, new ChromeOptions())
-        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30))
+        if (grailsGebSettings.implicitWait > 0) {
+            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30))
+        }
 
         currentBrowser.driver = driver
 

--- a/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
@@ -124,6 +124,12 @@ class WebDriverContainerHolder {
         if (grailsGebSettings.implicitlyWait > 0) {
             driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(grailsGebSettings.implicitlyWait))
         }
+        if (grailsGebSettings.pageLoadTimeout > 0) {
+            driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(grailsGebSettings.pageLoadTimeout))
+        }
+        if (grailsGebSettings.scriptTimeout > 0) {
+            driver.manage().timeouts().scriptTimeout(Duration.ofSeconds(grailsGebSettings.scriptTimeout))
+        }
 
         currentBrowser.driver = driver
 


### PR DESCRIPTION
Relates to https://github.com/grails/geb/issues/134#issuecomment-2646469174

At least for my project, removing it completely results in no errors and 3 minutes (5.0.0-M2; compared to 2m20s without container) instead of 20.

I have yet to figure out a [SSCCE](https://short.jonaspammer.at/test) that triggers the implicitWait

---

Sorry for the potential spam of PRs, I want to figure out accepted ways of how to implement things first before tackling my big goal of being able to use GebConfig.groovy (custom environmentized client/driver config + custom remote image) again