### PR TITLE
apply asset-pipeline-gradle plugin on spock-container-test-app

### DIFF
--- a/spock-container-test-app/build.gradle
+++ b/spock-container-test-app/build.gradle
@@ -17,12 +17,14 @@ buildscript {
     dependencies {
         classpath platform("org.apache.grails:grails-bom:$grailsVersion")
         classpath "org.apache.grails:grails-gradle-plugins"
+        classpath "com.bertramlabs.plugins:asset-pipeline-gradle"
     }
 }
 
 apply plugin: 'groovy'
 apply plugin: 'org.apache.grails.gradle.grails-web'
 apply plugin: 'org.apache.grails.gradle.grails-gsp'
+apply plugin: 'asset-pipeline'
 
 group = 'org.demo.spock'
 


### PR DESCRIPTION
when using `com.bertramlabs.plugins:asset-pipeline-grails`

resolves java.lang.ClassNotFoundException: org.graalvm.polyglot.Context

https://github.com/bertramdev/asset-pipeline/pull/370
https://github.com/bertramdev/asset-pipeline/pull/372
https://github.com/bertramdev/asset-pipeline/pull/374