### PR TITLE
fix: IContainerGebConfiguration fileDetector (#151 / #146)

### DIFF
--- a/src/testFixtures/groovy/grails/plugin/geb/ContainerGebConfiguration.groovy
+++ b/src/testFixtures/groovy/grails/plugin/geb/ContainerGebConfiguration.groovy
@@ -68,11 +68,11 @@ import java.lang.annotation.Target
 
 /**
  * Inheritable version of {@link ContainerGebConfiguration}
- * 
+ *
  * @since 4.2
  */
 interface IContainerGebConfiguration {
-    
+
     default String protocol() {
         ContainerGebConfiguration.DEFAULT_PROTOCOL
     }
@@ -83,5 +83,9 @@ interface IContainerGebConfiguration {
 
     default boolean reporting() {
         false
+    }
+
+    default Class<? extends ContainerFileDetector> fileDetector() {
+        ContainerGebConfiguration.DEFAULT_FILE_DETECTOR
     }
 }


### PR DESCRIPTION
https://github.com/apache/grails-geb/pull/151 didnt include  feature by https://github.com/apache/grails-geb/pull/146, so these errors happened for me:

ChildPreferenceInheritedConfigSpec
```
Cannot invoke "geb.test.GebTestManager.getBrowser()" because the return value of "grails.plugin.geb.ContainerGebSpec.getTestManager()" is nulljava.lang.NullPointerException: Cannot invoke "geb.test.GebTestManager.getBrowser()" because the return value of "grails.plugin.geb.ContainerGebSpec.getTestManager()" is null
	at grails.plugin.geb.support.delegate.BrowserDelegate$Trait$Helper.getBrowser(BrowserDelegate.groovy:50)
	at grails.plugin.geb.support.delegate.BrowserDelegate$Trait$Helper.methodMissing(BrowserDelegate.groovy:408)
	at grails.plugin.geb.WebDriverContainerHolder$WebDriverContainerConfiguration.<init>(WebDriverContainerHolder.groovy:230)
	at grails.plugin.geb.WebDriverContainerHolder.reinitialize(WebDriverContainerHolder.groovy:91)
	at grails.plugin.geb.GrailsContainerGebExtension.visitSpec_closure2(GrailsContainerGebExtension.groovy:75)
```

InheritedConfigSpec + MultipleInheritanceSpec
```
No signature of method: geb.navigator.DefaultNavigator.fileDetector() is applicable for argument types: () values: []groovy.lang.MissingMethodException: No signature of method: geb.navigator.DefaultNavigator.fileDetector() is applicable for argument types: () values: []
	at geb.navigator.DefaultNavigator.methodMissing(DefaultNavigator.groovy:808)
	at geb.content.PageContentSupport.methodMissing(PageContentSupport.groovy:35)
	at geb.Page.methodMissing(Page.groovy:110)
	at grails.plugin.geb.support.delegate.BrowserDelegate$Trait$Helper.methodMissing(BrowserDelegate.groovy:408)
	at grails.plugin.geb.WebDriverContainerHolder$WebDriverContainerConfiguration.<init>(WebDriverContainerHolder.groovy:230)
	at grails.plugin.geb.WebDriverContainerHolder.reinitialize(WebDriverContainerHolder.groovy:91)
	at grails.plugin.geb.GrailsContainerGebExtension.visitSpec_closure2(GrailsContainerGebExtension.groovy:75)
```

